### PR TITLE
M2AO-2000

### DIFF
--- a/Controller/Index/Index.php
+++ b/Controller/Index/Index.php
@@ -82,7 +82,7 @@ class Index implements HttpGetActionInterface
             $redirectPath = '';
             $redirect = false;
             // Get url_key from parameter passed by Router
-            $urlKey = explode("/", $this->request->getParam('url_key'));
+            $urlKey = explode("/", $this->request->getParam('url_key') ?? '');
             if (is_array($urlKey)) {
                 if (!isset($urlKey[1])) {
                     $redirectPath = '';


### PR DESCRIPTION
The partner URL was displaying the login form, which was incorrect since this URL has nothing associated with it. Once the small error was identified, it redirected to the home page.

🐛 fix :  partner URL, display login page without associated partner parameter